### PR TITLE
Create Decision Journal Template

### DIFF
--- a/backend/templates/decision_journal.json
+++ b/backend/templates/decision_journal.json
@@ -1,0 +1,220 @@
+{
+  "id": "decision_journal",
+  "name": "The Decision Journal",
+  "description": "Structure decision-making, analyze outcomes, and reduce cognitive bias",
+  "version": 1,
+  "icon": "🤔",
+  "color": "#F87171",
+  "ellie": {
+    "onSelect": {
+      "mood": "curious",
+      "message": "Time to think clearly and decide wisely. I'm here to help you analyze 🧠",
+      "animation": "sway"
+    },
+    "onStart": {
+      "mood": "curious",
+      "message": "A clear mind leads to clear decisions. Let's break this down."
+    },
+    "onComplete": {
+      "mood": "proud",
+      "message": "You've analyzed this thoroughly. Trust your judgment moving forward!",
+      "particleEffect": "sparkles",
+      "animation": "bounce"
+    },
+    "onSave": {
+      "mood": "celebrating",
+      "message": "Decision documented! This is how you build better judgment over time 🎯",
+      "particleEffect": "hearts"
+    },
+    "theme": {
+      "supportive": false,
+      "energetic": false,
+      "reflective": true
+    }
+  },
+  "sections": [
+    {
+      "id": "dilemma",
+      "title": "The Dilemma",
+      "type": "paragraph",
+      "placeholder": "What decision needs to be made, and what is the context? Include relevant background, constraints, and why this decision matters.",
+      "defaultValue": "",
+      "ellie": {
+        "onStart": {
+          "mood": "curious",
+          "message": "Let's define the decision clearly. What are you facing? 🤔"
+        },
+        "onComplete": {
+          "mood": "zen",
+          "message": "Good. Clear problem definition is half the solution 📝"
+        },
+        "hints": [
+          "What is the core decision you need to make?",
+          "What is the deadline or timeframe?",
+          "What constraints or limitations exist?",
+          "Why is this decision important?",
+          "What triggered the need for this decision?"
+        ],
+        "encouragement": {
+          "wordCount": {
+            "40": {
+              "mood": "curious",
+              "message": "You're clarifying the situation... keep going 🔍"
+            },
+            "100": {
+              "mood": "zen",
+              "message": "This context is valuable. You're thinking systematically 🧠"
+            },
+            "200": {
+              "mood": "proud",
+              "message": "Thorough context like this reduces blind spots! Excellent! 💎"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "options_analysis",
+      "title": "Options Analysis",
+      "type": "table",
+      "placeholder": "Analyze each option...",
+      "defaultValue": [],
+      "config": {
+        "columns": [
+          {
+            "key": "option",
+            "label": "Option",
+            "type": "text",
+            "width": "20%"
+          },
+          {
+            "key": "pros",
+            "label": "Pros",
+            "type": "text",
+            "width": "30%"
+          },
+          {
+            "key": "cons",
+            "label": "Cons",
+            "type": "text",
+            "width": "30%"
+          },
+          {
+            "key": "gut_feeling",
+            "label": "Gut Feeling (1-10)",
+            "type": "number",
+            "width": "20%"
+          }
+        ]
+      },
+      "ellie": {
+        "onStart": {
+          "mood": "curious",
+          "message": "Let's systematically compare your options. Structure beats intuition! 📊"
+        },
+        "onComplete": {
+          "mood": "excited",
+          "message": "Great analysis! Seeing options side-by-side reveals patterns 🔍"
+        },
+        "hints": [
+          "Consider at least 2-3 viable options",
+          "Be honest about the pros and cons",
+          "Your gut feeling is data too - what does it tell you?",
+          "Think about short-term vs long-term consequences",
+          "What assumptions are you making?"
+        ],
+        "encouragement": {
+          "itemCount": {
+            "1": {
+              "mood": "curious",
+              "message": "First option down. What are your alternatives? 🤔"
+            },
+            "2": {
+              "mood": "excited",
+              "message": "Two options! Now you can compare. Keep going! 📊"
+            },
+            "3": {
+              "mood": "proud",
+              "message": "Three options! This is thorough decision-making! 🎯",
+              "particleEffect": "sparkles"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "choice_rationale",
+      "title": "The Choice & Rationale",
+      "type": "paragraph",
+      "placeholder": "State your final decision and explain your reasoning. What factors were most important? What trade-offs are you accepting?",
+      "defaultValue": "",
+      "ellie": {
+        "onStart": {
+          "mood": "zen",
+          "message": "Time to decide. Trust the analysis you've done 💭"
+        },
+        "onComplete": {
+          "mood": "celebrating",
+          "message": "Decision made! Clear reasoning beats second-guessing 🎯",
+          "particleEffect": "hearts",
+          "animation": "bounce"
+        },
+        "hints": [
+          "Which option did you choose?",
+          "What were the deciding factors?",
+          "What trade-offs are you accepting?",
+          "What might you regret if you don't choose this?",
+          "How does this align with your values and goals?",
+          "What's your backup plan if this doesn't work?"
+        ],
+        "encouragement": {
+          "wordCount": {
+            "50": {
+              "mood": "zen",
+              "message": "You're articulating your reasoning clearly... 📝"
+            },
+            "100": {
+              "mood": "excited",
+              "message": "This level of clarity will help you commit to the decision! 💪"
+            },
+            "150": {
+              "mood": "celebrating",
+              "message": "Thorough rationale! You'll thank yourself later for this! 🌟"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "confidence_score",
+      "title": "Confidence Score",
+      "type": "scale",
+      "placeholder": "How confident are you that this is the right decision?",
+      "defaultValue": 5,
+      "config": {
+        "min": 1,
+        "max": 10,
+        "labels": {
+          "1": "Very Uncertain",
+          "10": "Highly Confident"
+        }
+      },
+      "ellie": {
+        "onStart": {
+          "mood": "curious",
+          "message": "Rate your confidence honestly. This is data for future you 📈"
+        },
+        "onComplete": {
+          "mood": "zen",
+          "message": "Confidence tracked! You can review this later to improve your judgment 🎯"
+        },
+        "hints": [
+          "Low confidence (1-4): Consider gathering more information",
+          "Medium confidence (5-7): Typical for most decisions",
+          "High confidence (8-10): Strong conviction, but watch for overconfidence",
+          "Confidence should match your analysis, not just your feelings"
+        ]
+      }
+    }
+  ]
+}

--- a/backend/templates/registry.json
+++ b/backend/templates/registry.json
@@ -6,5 +6,6 @@
   "express_examine_evolve.json",
   "grounding_5_4_3_2_1.json",
   "weekly_reset.json",
+  "decision_journal.json",
   "blank.json"
 ]

--- a/frontend/src/features/journal/components/sections/ScaleSection.tsx
+++ b/frontend/src/features/journal/components/sections/ScaleSection.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import '../../styles/sections.css'
+
+interface ScaleSectionProps {
+  value: number | string
+  onChange: (value: number) => void
+  placeholder?: string
+  disabled?: boolean
+  config?: {
+    min?: number
+    max?: number
+    labels?: Record<string, string>
+  }
+}
+
+export const ScaleSection: React.FC<ScaleSectionProps> = ({
+  value,
+  onChange,
+  placeholder = "Select a value",
+  disabled = false,
+  config = {}
+}) => {
+  const min = config.min ?? 1
+  const max = config.max ?? 10
+  const numValue = typeof value === 'number' ? value : parseInt(String(value)) || min
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(parseInt(e.target.value))
+  }
+
+  const getLabel = (val: number): string => {
+    if (config.labels) {
+      return config.labels[String(val)] || String(val)
+    }
+    return String(val)
+  }
+
+  return (
+    <div className="scale-section">
+      <div className="scale-container">
+        <div className="scale-value-display">
+          {numValue} / {max}
+        </div>
+        <input
+          type="range"
+          min={min}
+          max={max}
+          value={numValue}
+          onChange={handleChange}
+          className="scale-slider"
+          disabled={disabled}
+          aria-label={placeholder}
+        />
+        <div className="scale-labels">
+          <span className="scale-label-min">{getLabel(min)}</span>
+          <span className="scale-label-max">{getLabel(max)}</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/journal/components/sections/TableSection.tsx
+++ b/frontend/src/features/journal/components/sections/TableSection.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { Plus, X } from 'lucide-react'
+import { v4 as uuidv4 } from 'uuid'
+import '../../styles/sections.css'
+
+export interface TableRow {
+  id: string
+  [key: string]: string | number
+}
+
+interface TableColumn {
+  key: string
+  label: string
+  type?: 'text' | 'number'
+  width?: string
+}
+
+interface TableSectionProps {
+  value: TableRow[] | string
+  onChange: (value: TableRow[]) => void
+  placeholder?: string
+  disabled?: boolean
+  config?: {
+    columns?: TableColumn[]
+  }
+}
+
+export const TableSection: React.FC<TableSectionProps> = ({
+  value,
+  onChange,
+  placeholder = "Add data...",
+  disabled = false,
+  config = {}
+}) => {
+  // Default columns if not specified
+  const defaultColumns: TableColumn[] = [
+    { key: 'col1', label: 'Column 1', type: 'text' },
+    { key: 'col2', label: 'Column 2', type: 'text' }
+  ]
+
+  const columns = config.columns || defaultColumns
+
+  // Parse value
+  const rows: TableRow[] = typeof value === 'string'
+    ? (value ? JSON.parse(value) : [])
+    : value || []
+
+  const addRow = () => {
+    const newRow: TableRow = { id: uuidv4() }
+    columns.forEach(col => {
+      newRow[col.key] = col.type === 'number' ? 0 : ''
+    })
+    onChange([...rows, newRow])
+  }
+
+  const updateCell = (rowId: string, columnKey: string, cellValue: string | number) => {
+    onChange(rows.map(row =>
+      row.id === rowId ? { ...row, [columnKey]: cellValue } : row
+    ))
+  }
+
+  const removeRow = (rowId: string) => {
+    onChange(rows.filter(row => row.id !== rowId))
+  }
+
+  return (
+    <div className="table-section">
+      <div className="table-container">
+        <table className="journal-table">
+          <thead>
+            <tr>
+              {columns.map(col => (
+                <th key={col.key} style={{ width: col.width }}>
+                  {col.label}
+                </th>
+              ))}
+              <th style={{ width: '40px' }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id}>
+                {columns.map(col => (
+                  <td key={col.key}>
+                    {col.type === 'number' ? (
+                      <input
+                        type="number"
+                        value={row[col.key] || 0}
+                        onChange={(e) => updateCell(row.id, col.key, parseInt(e.target.value) || 0)}
+                        className="table-cell-input"
+                        disabled={disabled}
+                        placeholder={placeholder}
+                      />
+                    ) : (
+                      <textarea
+                        value={row[col.key] || ''}
+                        onChange={(e) => updateCell(row.id, col.key, e.target.value)}
+                        className="table-cell-input"
+                        disabled={disabled}
+                        placeholder={placeholder}
+                        rows={1}
+                      />
+                    )}
+                  </td>
+                ))}
+                <td>
+                  <button
+                    type="button"
+                    onClick={() => removeRow(row.id)}
+                    className="table-row-remove"
+                    disabled={disabled}
+                    title="Remove row"
+                  >
+                    <X size={14} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <button
+        type="button"
+        onClick={addRow}
+        className="table-add-button"
+        disabled={disabled}
+      >
+        <Plus size={16} />
+        Add Row
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/journal/pages/JournalCreatePage.tsx
+++ b/frontend/src/features/journal/pages/JournalCreatePage.tsx
@@ -517,9 +517,12 @@ export const JournalCreatePage: React.FC = () => {
                     />
                   ) : section.type === 'scale' ? (
                     <ScaleSection
-                      value={typeof templateData[section.id] === 'number' ? templateData[section.id] :
-                        typeof section.defaultValue === 'number' ? section.defaultValue :
-                        5}
+                      value={(() => {
+                        const val = templateData[section.id]
+                        if (typeof val === 'number') return val
+                        if (typeof section.defaultValue === 'number') return section.defaultValue
+                        return 5
+                      })()}
                       onChange={(value) => handleTemplateDataChange(section.id, value)}
                       placeholder={section.placeholder}
                       disabled={loading}

--- a/frontend/src/features/journal/pages/JournalCreatePage.tsx
+++ b/frontend/src/features/journal/pages/JournalCreatePage.tsx
@@ -7,6 +7,8 @@ import { QASection } from '../components/sections/QASection'
 import { AddSectionButton } from '../components/AddSectionButton'
 import { ListSection } from '../components/sections/ListSection'
 import { CheckboxSection } from '../components/sections/CheckboxSection'
+import { ScaleSection } from '../components/sections/ScaleSection'
+import { TableSection } from '../components/sections/TableSection'
 import AIWritingPrompts from '../../../components/AIWritingPrompts'
 import { useJournal } from '../hooks/useJournal'
 import { JournalContentManager } from '../../../lib/journal/JournalContentManager'
@@ -15,7 +17,7 @@ import { aiService } from '../../../services/ai'
 import { SmartEllie } from '../../../components/ellie'
 import { useEllieCustomizationContext } from '../../../hooks/useEllieCustomizationContext'
 import { useEllieJournalGuide } from '../hooks/useEllieJournalGuide'
-import type { Template, TemplateData, QAPair, ListItem } from '../types/template.types'
+import type { Template, TemplateData, QAPair, ListItem, TableRow } from '../types/template.types'
 import type { CustomSection } from '../types/customSection.types'
 import { Trash2, Edit2, Bot } from 'lucide-react'
 import '../styles/journal.css'
@@ -89,6 +91,8 @@ export const JournalCreatePage: React.FC = () => {
             initialData[section.id] = (Array.isArray(section.defaultValue) ? section.defaultValue : []) as QAPair[]
           } else if (section.type === 'list' || section.type === 'checkbox') {
             initialData[section.id] = (Array.isArray(section.defaultValue) ? section.defaultValue : []) as ListItem[]
+          } else if (section.type === 'table') {
+            initialData[section.id] = (Array.isArray(section.defaultValue) ? section.defaultValue : []) as TableRow[]
           } else if (section.type === 'scale') {
             initialData[section.id] = typeof section.defaultValue === 'number' ? section.defaultValue : 5
           } else {
@@ -98,6 +102,8 @@ export const JournalCreatePage: React.FC = () => {
           initialData[section.id] = [] as QAPair[]
         } else if (section.type === 'list' || section.type === 'checkbox') {
           initialData[section.id] = [] as ListItem[]
+        } else if (section.type === 'table') {
+          initialData[section.id] = [] as TableRow[]
         } else if (section.type === 'scale') {
           initialData[section.id] = 5
         } else {
@@ -114,7 +120,7 @@ export const JournalCreatePage: React.FC = () => {
     }
   }
 
-  const handleTemplateDataChange = (sectionId: string, value: string | QAPair[] | ListItem[] | number) => {
+  const handleTemplateDataChange = (sectionId: string, value: string | QAPair[] | ListItem[] | TableRow[] | number) => {
     // Get previous value before updating
     const previousValue = templateData[sectionId]
 
@@ -139,8 +145,13 @@ export const JournalCreatePage: React.FC = () => {
       if (wordCount > 0 && (!previousValue || previousValue === '')) {
         handleSectionComplete(sectionId)
       }
+    } else if (typeof value === 'number') {
+      // Scale sections - mark as complete when user interacts
+      if (previousValue === undefined || previousValue === 5) {
+        handleSectionComplete(sectionId)
+      }
     } else if (Array.isArray(value)) {
-      // Item count for Q&A and list sections
+      // Item count for Q&A, list, and table sections
       updateSectionProgress(sectionId, { itemCount: value.length })
 
       // Mark section as complete if it has items and was previously empty
@@ -493,6 +504,26 @@ export const JournalCreatePage: React.FC = () => {
                       onChange={(value) => handleTemplateDataChange(section.id, value)}
                       placeholder={section.placeholder}
                       disabled={loading}
+                    />
+                  ) : section.type === 'table' ? (
+                    <TableSection
+                      value={(Array.isArray(templateData[section.id]) ? templateData[section.id] :
+                        Array.isArray(section.defaultValue) ? section.defaultValue :
+                        []) as TableRow[]}
+                      onChange={(value) => handleTemplateDataChange(section.id, value)}
+                      placeholder={section.placeholder}
+                      disabled={loading}
+                      config={section.config}
+                    />
+                  ) : section.type === 'scale' ? (
+                    <ScaleSection
+                      value={typeof templateData[section.id] === 'number' ? templateData[section.id] :
+                        typeof section.defaultValue === 'number' ? section.defaultValue :
+                        5}
+                      onChange={(value) => handleTemplateDataChange(section.id, value)}
+                      placeholder={section.placeholder}
+                      disabled={loading}
+                      config={section.config}
                     />
                   ) : (
                     <RichTextEditor

--- a/frontend/src/features/journal/pages/JournalEditPage.tsx
+++ b/frontend/src/features/journal/pages/JournalEditPage.tsx
@@ -6,6 +6,8 @@ import { QASection } from '../components/sections/QASection'
 import { AddSectionButton } from '../components/AddSectionButton'
 import { ListSection } from '../components/sections/ListSection'
 import { CheckboxSection } from '../components/sections/CheckboxSection'
+import { ScaleSection } from '../components/sections/ScaleSection'
+import { TableSection } from '../components/sections/TableSection'
 import { useJournal } from '../hooks/useJournal'
 import { useAuth } from '../../../stores/authStore'
 import { getTemplate } from '../services/templateApi'
@@ -15,7 +17,7 @@ import { aiService } from '../../../services/ai'
 import { SmartEllie } from '../../../components/ellie'
 import { useEllieCustomizationContext } from '../../../hooks/useEllieCustomizationContext'
 import { useEllieJournalGuide } from '../hooks/useEllieJournalGuide'
-import type { Template, TemplateData, QAPair, ListItem } from '../types/template.types'
+import type { Template, TemplateData, QAPair, ListItem, TableRow } from '../types/template.types'
 import type { CustomSection } from '../types/customSection.types'
 import { Trash2, Edit2, Bot } from 'lucide-react'
 import '../styles/journal.css'
@@ -116,7 +118,7 @@ export const JournalEditPage: React.FC = () => {
               const isCustomSection = sectionId.startsWith('custom_')
 
               // Parse content based on section type
-              let parsedContent: string | QAPair[] | ListItem[] | number
+              let parsedContent: string | QAPair[] | ListItem[] | TableRow[] | number
               if (section.type === 'q_and_a') {
                 try {
                   // Parse JSON string back to QAPair array
@@ -133,8 +135,19 @@ export const JournalEditPage: React.FC = () => {
                   // If parsing fails, default to empty array
                   parsedContent = []
                 }
+              } else if (section.type === 'table') {
+                try {
+                  // Parse JSON string back to TableRow array
+                  parsedContent = JSON.parse(section.content) as TableRow[]
+                } catch {
+                  // If parsing fails, default to empty array
+                  parsedContent = []
+                }
+              } else if (section.type === 'scale') {
+                // Parse number for scale type
+                parsedContent = typeof section.content === 'number' ? section.content : parseInt(section.content) || 5
               } else {
-                // Other sections are plain strings or numbers
+                // Other sections are plain strings
                 parsedContent = section.content
               }
 
@@ -184,7 +197,7 @@ export const JournalEditPage: React.FC = () => {
               mainContent = section.content
             } else if (sectionId.startsWith('custom_')) {
               // This is a custom section
-              let parsedContent: string | QAPair[] | ListItem[] | number
+              let parsedContent: string | QAPair[] | ListItem[] | TableRow[] | number
 
               if (section.type === 'q_and_a') {
                 try {
@@ -198,6 +211,14 @@ export const JournalEditPage: React.FC = () => {
                 } catch {
                   parsedContent = []
                 }
+              } else if (section.type === 'table') {
+                try {
+                  parsedContent = JSON.parse(section.content) as TableRow[]
+                } catch {
+                  parsedContent = []
+                }
+              } else if (section.type === 'scale') {
+                parsedContent = typeof section.content === 'number' ? section.content : parseInt(section.content) || 5
               } else {
                 parsedContent = section.content
               }
@@ -233,7 +254,7 @@ export const JournalEditPage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [journal])
 
-  const handleTemplateDataChange = (sectionId: string, value: string | QAPair[] | ListItem[] | number) => {
+  const handleTemplateDataChange = (sectionId: string, value: string | QAPair[] | ListItem[] | TableRow[] | number) => {
     // Get previous value before updating
     const previousValue = templateData[sectionId]
 
@@ -258,8 +279,13 @@ export const JournalEditPage: React.FC = () => {
       if (wordCount > 0 && (!previousValue || previousValue === '')) {
         handleSectionComplete(sectionId)
       }
+    } else if (typeof value === 'number') {
+      // Scale sections - mark as complete when user interacts
+      if (previousValue === undefined || previousValue === 5) {
+        handleSectionComplete(sectionId)
+      }
     } else if (Array.isArray(value)) {
-      // Item count for Q&A and list sections
+      // Item count for Q&A, list, and table sections
       updateSectionProgress(sectionId, { itemCount: value.length })
 
       // Mark section as complete if it has items and was previously empty
@@ -314,6 +340,24 @@ export const JournalEditPage: React.FC = () => {
                   type: section.type
                 }
               }
+            } else if (section.type === 'table') {
+              // Table sections store arrays of TableRow objects
+              if (Array.isArray(sectionContent) && sectionContent.length > 0) {
+                sections[section.id] = {
+                  content: JSON.stringify(sectionContent),
+                  title: section.title,
+                  type: section.type
+                }
+              }
+            } else if (section.type === 'scale') {
+              // Scale sections store numbers
+              if (typeof sectionContent === 'number') {
+                sections[section.id] = {
+                  content: String(sectionContent),
+                  title: section.title,
+                  type: section.type
+                }
+              }
             } else {
               // Other sections store strings
               if (sectionContent && typeof sectionContent === 'string' && sectionContent.trim()) {
@@ -329,11 +373,20 @@ export const JournalEditPage: React.FC = () => {
 
         // Add custom sections
         customSections.forEach(section => {
-          if (section.type === 'q_and_a' || section.type === 'list' || section.type === 'checkbox' || section.type === 'checkbox') {
-            // Q&A and List sections store arrays
+          if (section.type === 'q_and_a' || section.type === 'list' || section.type === 'checkbox' || section.type === 'table') {
+            // Q&A, List, Checkbox, and Table sections store arrays
             if (Array.isArray(section.content) && section.content.length > 0) {
               sections[section.id] = {
                 content: JSON.stringify(section.content),
+                title: section.title,
+                type: section.type
+              }
+            }
+          } else if (section.type === 'scale') {
+            // Scale sections store numbers
+            if (typeof section.content === 'number') {
+              sections[section.id] = {
+                content: String(section.content),
                 title: section.title,
                 type: section.type
               }
@@ -611,6 +664,26 @@ export const JournalEditPage: React.FC = () => {
                     onChange={(value) => handleTemplateDataChange(section.id, value)}
                     placeholder={section.placeholder}
                     disabled={isSubmitting}
+                  />
+                ) : section.type === 'table' ? (
+                  <TableSection
+                    value={(Array.isArray(templateData[section.id]) ? templateData[section.id] :
+                      Array.isArray(section.defaultValue) ? section.defaultValue :
+                      []) as TableRow[]}
+                    onChange={(value) => handleTemplateDataChange(section.id, value)}
+                    placeholder={section.placeholder}
+                    disabled={isSubmitting}
+                    config={section.config}
+                  />
+                ) : section.type === 'scale' ? (
+                  <ScaleSection
+                    value={typeof templateData[section.id] === 'number' ? templateData[section.id] :
+                      typeof section.defaultValue === 'number' ? section.defaultValue :
+                      5}
+                    onChange={(value) => handleTemplateDataChange(section.id, value)}
+                    placeholder={section.placeholder}
+                    disabled={isSubmitting}
+                    config={section.config}
                   />
                 ) : (
                   <RichTextEditor

--- a/frontend/src/features/journal/pages/JournalEditPage.tsx
+++ b/frontend/src/features/journal/pages/JournalEditPage.tsx
@@ -677,9 +677,12 @@ export const JournalEditPage: React.FC = () => {
                   />
                 ) : section.type === 'scale' ? (
                   <ScaleSection
-                    value={typeof templateData[section.id] === 'number' ? templateData[section.id] :
-                      typeof section.defaultValue === 'number' ? section.defaultValue :
-                      5}
+                    value={(() => {
+                      const val = templateData[section.id]
+                      if (typeof val === 'number') return val
+                      if (typeof section.defaultValue === 'number') return section.defaultValue
+                      return 5
+                    })()}
                     onChange={(value) => handleTemplateDataChange(section.id, value)}
                     placeholder={section.placeholder}
                     disabled={isSubmitting}

--- a/frontend/src/features/journal/pages/JournalViewPage.tsx
+++ b/frontend/src/features/journal/pages/JournalViewPage.tsx
@@ -492,6 +492,45 @@ ${content}
                         )
                       }
                     })()
+                  ) : section.type === 'table' ? (
+                    // Render Table section
+                    (() => {
+                      try {
+                        const tableRows = JSON.parse(section.content) as Array<Record<string, string | number>>
+                        if (tableRows.length === 0) return <div className="empty-section">No data</div>
+                        // Get column keys from first row (excluding 'id')
+                        const columns = Object.keys(tableRows[0]).filter(key => key !== 'id')
+                        return (
+                          <div className="table-view-section">
+                            <table className="journal-table-view">
+                              <thead>
+                                <tr>
+                                  {columns.map(col => (
+                                    <th key={col}>{col.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}</th>
+                                  ))}
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {tableRows.map((row, index) => (
+                                  <tr key={row.id || index}>
+                                    {columns.map(col => (
+                                      <td key={col}>{row[col]}</td>
+                                    ))}
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </div>
+                        )
+                      } catch {
+                        return <div className="empty-section">Invalid table data</div>
+                      }
+                    })()
+                  ) : section.type === 'scale' ? (
+                    // Render Scale section
+                    <div className="scale-view-section">
+                      <div className="scale-value-large">{section.content} / 10</div>
+                    </div>
                   ) : (
                     // Render other section types with highlighting
                     <HighlightableText

--- a/frontend/src/features/journal/styles/sections.css
+++ b/frontend/src/features/journal/styles/sections.css
@@ -848,6 +848,330 @@
 }
 
 /* ============================
+   Scale Section Styles
+   ============================ */
+
+.scale-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  background: var(--theme-bg-surface);
+  border-radius: 8px;
+  border: 1px solid var(--theme-border-light);
+}
+
+.scale-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.scale-value-display {
+  text-align: center;
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--theme-primary-600);
+  padding: 12px;
+  background: var(--theme-bg-elevated);
+  border-radius: 8px;
+  border: 2px solid var(--theme-primary-200);
+}
+
+.dark .scale-value-display {
+  color: var(--theme-primary-400);
+  border-color: var(--theme-primary-800);
+}
+
+.scale-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  background: var(--theme-bg-elevated);
+  outline: none;
+  border: 1px solid var(--theme-border-base);
+  cursor: pointer;
+}
+
+.scale-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--theme-primary-600);
+  cursor: pointer;
+  border: 3px solid white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: all 0.2s ease;
+}
+
+.scale-slider::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
+.scale-slider::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--theme-primary-600);
+  cursor: pointer;
+  border: 3px solid white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: all 0.2s ease;
+}
+
+.scale-slider::-moz-range-thumb:hover {
+  transform: scale(1.15);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
+.scale-slider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.scale-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  color: var(--theme-text-secondary);
+  font-weight: 500;
+  padding: 0 4px;
+}
+
+/* ============================
+   Table Section Styles
+   ============================ */
+
+.table-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: var(--theme-bg-surface);
+  border-radius: 8px;
+  border: 1px solid var(--theme-border-light);
+}
+
+.table-container {
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid var(--theme-border-base);
+  background: var(--theme-bg-base);
+}
+
+.journal-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.journal-table thead {
+  background: var(--theme-bg-elevated);
+  border-bottom: 2px solid var(--theme-border-base);
+}
+
+.journal-table th {
+  padding: 12px 14px;
+  text-align: left;
+  font-weight: 600;
+  color: var(--theme-text-primary);
+  white-space: nowrap;
+}
+
+.journal-table tbody tr {
+  border-bottom: 1px solid var(--theme-border-light);
+  transition: background 0.2s ease;
+}
+
+.journal-table tbody tr:hover {
+  background: var(--theme-bg-surface);
+}
+
+.journal-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.journal-table td {
+  padding: 10px 14px;
+  vertical-align: top;
+}
+
+.table-cell-input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--theme-border-light);
+  border-radius: 4px;
+  font-size: 13px;
+  line-height: 1.5;
+  background: var(--theme-bg-elevated);
+  color: var(--theme-text-primary);
+  font-family: inherit;
+  resize: none;
+  transition: all 0.2s ease;
+}
+
+.table-cell-input:focus {
+  outline: none;
+  border-color: var(--theme-primary-600);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+}
+
+.dark .table-cell-input:focus {
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.2);
+}
+
+.table-cell-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background: var(--theme-bg-surface);
+}
+
+.table-cell-input[type="number"] {
+  text-align: center;
+  font-weight: 600;
+}
+
+.table-row-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--theme-text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  padding: 0;
+}
+
+.table-row-remove:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--theme-error-600);
+}
+
+.dark .table-row-remove:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.2);
+  color: var(--theme-error-400);
+}
+
+.table-row-remove:disabled {
+  cursor: not-allowed;
+  opacity: 0.3;
+}
+
+.table-add-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border: 2px dashed var(--theme-border-light);
+  background: transparent;
+  color: var(--theme-text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+.table-add-button:hover:not(:disabled) {
+  border-color: var(--theme-primary-600);
+  color: var(--theme-primary-600);
+  background: rgba(59, 130, 246, 0.05);
+}
+
+.dark .table-add-button:hover:not(:disabled) {
+  background: rgba(96, 165, 250, 0.1);
+}
+
+.table-add-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ============================
+   View-Only Display Styles
+   ============================ */
+
+.table-view-section {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.journal-table-view {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  margin: 16px 0;
+  background: var(--theme-bg-elevated);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.journal-table-view thead {
+  background: var(--theme-bg-surface);
+  border-bottom: 2px solid var(--theme-border-base);
+}
+
+.journal-table-view th {
+  padding: 12px 16px;
+  text-align: left;
+  font-weight: 600;
+  color: var(--theme-text-primary);
+  white-space: nowrap;
+}
+
+.journal-table-view tbody tr {
+  border-bottom: 1px solid var(--theme-border-light);
+}
+
+.journal-table-view tbody tr:last-child {
+  border-bottom: none;
+}
+
+.journal-table-view td {
+  padding: 10px 16px;
+  color: var(--theme-text-secondary);
+}
+
+.scale-view-section {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  background: var(--theme-bg-surface);
+  border-radius: 8px;
+  margin: 16px 0;
+}
+
+.scale-value-large {
+  font-size: 48px;
+  font-weight: 700;
+  color: var(--theme-primary-600);
+  text-align: center;
+}
+
+.dark .scale-value-large {
+  color: var(--theme-primary-400);
+}
+
+.empty-section {
+  padding: 20px;
+  text-align: center;
+  color: var(--theme-text-muted);
+  font-style: italic;
+}
+
+/* ============================
    Responsive Design
    ============================ */
 

--- a/frontend/src/features/journal/types/template.types.ts
+++ b/frontend/src/features/journal/types/template.types.ts
@@ -35,6 +35,18 @@ export interface ListItem {
   text: string
 }
 
+export interface TableRow {
+  id: string
+  [key: string]: string | number
+}
+
+export interface TableColumn {
+  key: string
+  label: string
+  type?: 'text' | 'number'
+  width?: string
+}
+
 export interface TemplateSection {
   id: string
   title: string
@@ -48,6 +60,7 @@ export interface TemplateSection {
     min?: number
     max?: number
     labels?: Record<string, string>
+    columns?: TableColumn[]
   }
 
   // Ellie guidance fields
@@ -94,5 +107,5 @@ export interface TemplateListResponse {
 }
 
 export interface TemplateData {
-  [sectionId: string]: string | QAPair[] | ListItem[] | number
+  [sectionId: string]: string | QAPair[] | ListItem[] | TableRow[] | number
 }


### PR DESCRIPTION
This commit implements a fully functional Decision Journal template that helps users structure decision-making, analyze outcomes, and reduce cognitive bias.

Backend changes:
- Created decision_journal.json template with 4 sections:
  * The Dilemma (paragraph)
  * Options Analysis (table)
  * The Choice & Rationale (paragraph)
  * Confidence Score (scale 1-10)
- Updated registry.json to include the new template
- Template features Ellie guidance with analytical/curious mood

Frontend changes:
- Created ScaleSection component for rendering scale inputs (1-10 slider)
- Created TableSection component for rendering flexible table inputs
- Updated template types to include TableRow and TableColumn interfaces
- Enhanced JournalCreatePage to support scale and table section types
- Enhanced JournalEditPage to parse, serialize, and render scale/table sections
- Enhanced JournalViewPage to display scale and table data in read-only mode
- Added comprehensive CSS styles for scale and table sections
- Added view-only display styles for table and scale sections

Template specifications:
- Icon: 🤔
- Color: Red (#F87171)
- Ellie behavior: Analytical & Objective (Curious)
- onStart: "A clear mind leads to clear decisions. Let's break this down."
- onComplete: "You've analyzed this thoroughly. Trust your judgment moving forward!"

All sections include detailed Ellie guidance with hints, encouragement based on progress metrics (word count, item count), and mood changes throughout the journaling process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)