### PR TITLE
Relocate Ellie Control Button to Bottom Bar

### DIFF
--- a/frontend/src/components/ellie/EllieBottomBar.css
+++ b/frontend/src/components/ellie/EllieBottomBar.css
@@ -1,0 +1,47 @@
+/**
+ * Ellie Bottom Bar Styles
+ * Transparent bottom bar with Ellie control button
+ */
+
+.ellie-bottom-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  background: linear-gradient(
+    to top,
+    rgba(255, 255, 255, 0.95) 0%,
+    rgba(255, 255, 255, 0.8) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 0 24px 12px 24px;
+  z-index: 100;
+  pointer-events: none; /* Allow clicks through transparent areas */
+}
+
+.ellie-bottom-bar__content {
+  pointer-events: auto; /* Re-enable clicks on the control panel */
+}
+
+/* Dark mode support */
+.dark .ellie-bottom-bar {
+  background: linear-gradient(
+    to top,
+    rgba(15, 23, 42, 0.95) 0%,
+    rgba(15, 23, 42, 0.8) 50%,
+    rgba(15, 23, 42, 0) 100%
+  );
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .ellie-bottom-bar {
+    padding: 0 16px 12px 16px;
+  }
+}

--- a/frontend/src/components/ellie/EllieBottomBar.tsx
+++ b/frontend/src/components/ellie/EllieBottomBar.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { EllieControlPanel } from './EllieControlPanel';
+import type { EllieMode } from './modes/types';
+import './EllieBottomBar.css';
+
+export interface EllieBottomBarProps {
+  currentMode?: EllieMode;
+  onModeChange?: (mode: EllieMode) => void;
+  onMinimize?: () => void;
+  onCustomize?: () => void;
+  onReset?: () => void;
+  opacity?: number;
+  onOpacityChange?: (opacity: number) => void;
+}
+
+/**
+ * Transparent bottom bar with Ellie control button
+ * Designed to be used on sign-in pages and other non-dashboard pages
+ */
+export const EllieBottomBar: React.FC<EllieBottomBarProps> = ({
+  currentMode = 'companion',
+  onModeChange,
+  onMinimize,
+  onCustomize,
+  onReset,
+  opacity = 1.0,
+  onOpacityChange,
+}) => {
+  return (
+    <div className="ellie-bottom-bar">
+      <div className="ellie-bottom-bar__content">
+        <EllieControlPanel
+          currentMode={currentMode}
+          onModeChange={onModeChange || (() => {})}
+          onMinimize={onMinimize}
+          onCustomize={onCustomize}
+          onReset={onReset}
+          opacity={opacity}
+          onOpacityChange={onOpacityChange}
+          showOpacityControl={true}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default EllieBottomBar;

--- a/frontend/src/components/ellie/index.ts
+++ b/frontend/src/components/ellie/index.ts
@@ -5,6 +5,8 @@ export { SimpleSmartEllie as SmartEllie } from './SimpleSmartEllie'
 export type { SimpleSmartEllieProps as SmartEllieProps } from './SimpleSmartEllie'
 export { AnimatedShihTzu } from './AnimatedShihTzu'
 export { EllieCustomizer, type EllieCustomization } from './EllieCustomizer'
+export { EllieBottomBar } from './EllieBottomBar'
+export type { EllieBottomBarProps } from './EllieBottomBar'
 
 // Modular component system (recommended)
 export { ModularEnhancedShihTzu } from './ModularEnhancedShihTzu'

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../stores/authStore'
-import { SmartEllie } from '../components/ellie'
+import { SmartEllie, EllieBottomBar } from '../components/ellie'
 import { ThemeToggle } from '../components/theme'
 import { useEffect, useState } from 'react'
+import type { EllieMode } from '../components/ellie/modes/types'
 import './Landing.css'
 
 export function Landing() {
@@ -12,6 +13,8 @@ export function Landing() {
 
   // Ellie companion state
   const [mood, setMood] = useState<'idle' | 'happy' | 'excited' | 'curious' | 'playful' | 'sleeping' | 'walking' | 'concerned' | 'proud' | 'zen' | 'celebrating'>('excited');
+  const [ellieMode, setEllieMode] = useState<EllieMode>('companion');
+  const [ellieOpacity, setEllieOpacity] = useState(1.0);
 
   // Celebration function for Ellie
   const celebrate = () => {
@@ -203,7 +206,15 @@ export function Landing() {
         particleEffect={mood === 'celebrating' ? 'hearts' : null}
         className="hidden lg:block"
         enableSmartPositioning={true}
-        showControlPanel={true}
+        showControlPanel={false}
+      />
+
+      {/* Transparent Bottom Bar with Ellie Control */}
+      <EllieBottomBar
+        currentMode={ellieMode}
+        onModeChange={setEllieMode}
+        opacity={ellieOpacity}
+        onOpacityChange={setEllieOpacity}
       />
     </div>
   )

--- a/frontend/src/pages/SignIn.tsx
+++ b/frontend/src/pages/SignIn.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { AuthLayout } from '../components/auth/AuthLayout';
 import { SignInForm } from '../components/auth/SignInForm';
 import { useAuth } from '../stores/authStore';
 import type { SignInData } from '../types';
+import { SmartEllie, EllieBottomBar } from '../components/ellie';
+import type { EllieMode } from '../components/ellie/modes/types';
 
 export const SignIn: React.FC = () => {
   const navigate = useNavigate();
@@ -12,6 +14,11 @@ export const SignIn: React.FC = () => {
 
   // Extract success message from navigation state
   const successMessage = location.state?.successMessage || null;
+
+  // Ellie companion state
+  const [mood, setMood] = useState<'idle' | 'happy' | 'excited' | 'curious' | 'playful' | 'sleeping' | 'walking' | 'concerned' | 'proud' | 'zen' | 'celebrating'>('happy');
+  const [ellieMode, setEllieMode] = useState<EllieMode>('companion');
+  const [ellieOpacity, setEllieOpacity] = useState(1.0);
 
   const handleSignIn = async (data: SignInData & { rememberMe?: boolean }) => {
     try {
@@ -27,14 +34,35 @@ export const SignIn: React.FC = () => {
   };
 
   return (
-    <AuthLayout>
-      <SignInForm
-        onSubmit={handleSignIn}
-        onSwitchToSignUp={handleSwitchToSignUp}
-        isLoading={isLoading}
-        error={error}
-        successMessage={successMessage}
+    <>
+      <AuthLayout>
+        <SignInForm
+          onSubmit={handleSignIn}
+          onSwitchToSignUp={handleSwitchToSignUp}
+          isLoading={isLoading}
+          error={error}
+          successMessage={successMessage}
+        />
+      </AuthLayout>
+
+      {/* Ellie Companion */}
+      <SmartEllie
+        mood={mood}
+        size="md"
+        showThoughtBubble={true}
+        thoughtText="Ready to sign in? 😊"
+        onClick={() => setMood(mood === 'happy' ? 'excited' : 'happy')}
+        enableSmartPositioning={true}
+        showControlPanel={false}
       />
-    </AuthLayout>
+
+      {/* Transparent Bottom Bar with Ellie Control */}
+      <EllieBottomBar
+        currentMode={ellieMode}
+        onModeChange={setEllieMode}
+        opacity={ellieOpacity}
+        onOpacityChange={setEllieOpacity}
+      />
+    </>
   );
 };

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,13 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AuthLayout } from '../components/auth/AuthLayout';
 import { SignUpForm } from '../components/auth/SignUpForm';
 import { useAuth } from '../stores/authStore';
 import type { SignUpData } from '../types';
+import { SmartEllie, EllieBottomBar } from '../components/ellie';
+import type { EllieMode } from '../components/ellie/modes/types';
 
 export const SignUp: React.FC = () => {
   const navigate = useNavigate();
   const { signUp, isLoading, error } = useAuth();
+
+  // Ellie companion state
+  const [mood, setMood] = useState<'idle' | 'happy' | 'excited' | 'curious' | 'playful' | 'sleeping' | 'walking' | 'concerned' | 'proud' | 'zen' | 'celebrating'>('excited');
+  const [ellieMode, setEllieMode] = useState<EllieMode>('companion');
+  const [ellieOpacity, setEllieOpacity] = useState(1.0);
 
   const handleSignUp = async (data: SignUpData) => {
     try {
@@ -29,13 +36,34 @@ export const SignUp: React.FC = () => {
   };
 
   return (
-    <AuthLayout>
-      <SignUpForm
-        onSubmit={handleSignUp}
-        onSwitchToSignIn={handleSwitchToSignIn}
-        isLoading={isLoading}
-        error={error}
+    <>
+      <AuthLayout>
+        <SignUpForm
+          onSubmit={handleSignUp}
+          onSwitchToSignIn={handleSwitchToSignIn}
+          isLoading={isLoading}
+          error={error}
+        />
+      </AuthLayout>
+
+      {/* Ellie Companion */}
+      <SmartEllie
+        mood={mood}
+        size="md"
+        showThoughtBubble={true}
+        thoughtText="Let's get started! 🎉"
+        onClick={() => setMood(mood === 'excited' ? 'celebrating' : 'excited')}
+        enableSmartPositioning={true}
+        showControlPanel={false}
       />
-    </AuthLayout>
+
+      {/* Transparent Bottom Bar with Ellie Control */}
+      <EllieBottomBar
+        currentMode={ellieMode}
+        onModeChange={setEllieMode}
+        opacity={ellieOpacity}
+        onOpacityChange={setEllieOpacity}
+      />
+    </>
   );
 };


### PR DESCRIPTION
Create a new reusable EllieBottomBar component that provides a transparent bottom bar with the Ellie control button. This bar is now available on all sign-in related pages (Landing, SignIn, SignUp), providing consistent access to Ellie customization controls across the authentication flow.

Changes:
- Create EllieBottomBar component with transparent gradient styling
- Add EllieBottomBar to Landing, SignIn, and SignUp pages
- Move Ellie control from floating panel to bottom bar on auth pages
- Update SimpleSmartEllie to hide control panel when bottom bar is used
- Export EllieBottomBar from ellie components index

🤖 Generated with [Claude Code](https://claude.com/claude-code)