### PR TITLE
Fix mobile layout on journal read page

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,11 +1,14 @@
 #root {
-  max-width: 1280px;
+  max-width: 100%;
+  width: 100%;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0;
   text-align: center;
   background-color: var(--theme-bg-base);
   color: var(--theme-text-primary);
   transition: background-color 0.3s ease, color 0.3s ease;
+  box-sizing: border-box;
+  overflow-x: hidden;
 }
 
 .logo {


### PR DESCRIPTION
The #root element had fixed padding (2rem) and max-width (1280px) that caused mobile devices to render pages wider than the viewport, requiring users to zoom out.

Changes:
- Remove fixed padding from #root (changed from 2rem to 0)
- Set max-width to 100% instead of 1280px for full mobile viewport usage
- Add width: 100% to ensure proper viewport spanning
- Add box-sizing: border-box for correct width calculations
- Add overflow-x: hidden to prevent horizontal scrolling

This ensures the page properly fits mobile viewports without requiring zoom adjustments. Individual page components already have appropriate responsive padding.