### PR TITLE
Add back navigation to journal detail view

### DIFF
--- a/frontend/src/features/journal/pages/JournalViewPage.tsx
+++ b/frontend/src/features/journal/pages/JournalViewPage.tsx
@@ -123,7 +123,7 @@ export const JournalViewPage: React.FC = () => {
     try {
       setIsDeleting(true)
       await deleteJournal(spaceId, journalId)
-      navigate(`/spaces/${spaceId}`)
+      navigate(`/spaces/${spaceId}/journals`)
     } catch (err) {
       console.error('Failed to delete journal:', err)
     } finally {
@@ -133,7 +133,7 @@ export const JournalViewPage: React.FC = () => {
 
   const handleBack = () => {
     if (journal?.spaceId) {
-      navigate(`/spaces/${journal.spaceId}`)
+      navigate(`/spaces/${journal.spaceId}/journals`)
     } else {
       navigate('/dashboard')
     }


### PR DESCRIPTION
When viewing or deleting a journal, the back button and delete action now correctly navigate to the space's journal list page (/spaces/:spaceId/journals) instead of the space detail page.

Changes:
- Updated handleBack() to navigate to journal list
- Updated handleDelete() to navigate to journal list after deletion